### PR TITLE
Fix copy when the two patch data blocks are overlapping

### DIFF
--- a/MWBDiff.cpp
+++ b/MWBDiff.cpp
@@ -99,6 +99,23 @@ size_t addr_decode(VcdState* vcd, size_t here, int mode)
     return address;
 }
 
+void memmove2(void* _dest, void* _src, size_t n)
+{
+	byte* dest{ (byte*)_dest };
+	byte* src{ (byte*)_src };
+
+	if (&dest[n] <= src || &src[n] <= dest)
+	{
+		memcpy(dest, src, n);
+		return; // no overlap
+	}
+
+	for (size_t i = 0; i < n; i++)
+	{
+		dest[i] = src[i];
+	}
+}
+
 bool bdiff_internal(diffInfo* s_diffInfo, 
     unsigned char* (__fastcall* loadSourceData)(diffInfo* s_diffInfo, size_t offset, size_t size),
     unsigned char* (__fastcall* loadPatchData)(diffInfo* s_diffInfo, size_t offset, size_t size, size_t* pOffset),
@@ -221,7 +238,7 @@ bool bdiff_internal(diffInfo* s_diffInfo,
                 {
                     v68 = (v72 - v71 + v70);
                 }
-                memcpy(v44, v68, size);
+                memmove2(v44, v68, size);
                 v44 += size;
                 v62 = oldIns;
                 continue;


### PR DESCRIPTION
Hi, I was using this bdiff implementation to decompress some fastfiles when I noticed it was working for iw engine, but not for treyarch ones. Some parts were empty (see picture)

<img width="2246" height="777" alt="image" src="https://github.com/user-attachments/assets/44b9b0b9-4d4c-4b80-879a-8178940b90bf" />


The format is the same for both engines, but the Treyarch diff tool seems to accept patch data from itself in a copy instruction.

For example, if the patch data are:

```
012345______________________________
```

And the instruction is

```
copy(0,6,30)
```

It expects to reuse the new data

```
012345012345012345012345012345012345
```

To fix that, I have added a simple check for overlapping data, but a fancy move can also do it.